### PR TITLE
obsws: Send text in coroutine

### DIFF
--- a/test/test_obsws.py
+++ b/test/test_obsws.py
@@ -45,6 +45,7 @@ class TestObsWsEmitter(unittest.IsolatedAsyncioTestCase):
         ctx.get_instance.assert_called_once_with(name=cfg_src)
 
         await obj.update('test text', args=None)
+        await asyncio.gather(obj._sending_task, return_exceptions=True)
 
         MockWebSocketClient.assert_called_with(url=cfg_url, password=cfg_password)
         mock_ws.connect.assert_awaited_once()
@@ -57,6 +58,7 @@ class TestObsWsEmitter(unittest.IsolatedAsyncioTestCase):
         ))
 
         await obj.update('2nd text', args=None)
+        await asyncio.gather(obj._sending_task, return_exceptions=True)
 
         mock_ws.connect.assert_awaited_once()
         mock_ws.call.assert_awaited_with(obsws.simpleobsws.Request(
@@ -88,6 +90,7 @@ class TestObsWsEmitter(unittest.IsolatedAsyncioTestCase):
         ctx.get_instance.assert_called_once_with(name=None)
 
         await obj.update(None, args=None)
+        await asyncio.gather(obj._sending_task, return_exceptions=True)
 
         MockWebSocketClient.assert_called_with(url=cfg_url, password=None)
         mock_ws.wait_until_identified.assert_not_called()
@@ -126,6 +129,7 @@ class TestObsWsEmitter(unittest.IsolatedAsyncioTestCase):
         ctx.get_instance.assert_called_once_with(name=None)
 
         await obj.update('', args=None)
+        await asyncio.gather(obj._sending_task, return_exceptions=True)
 
         MockWebSocketClient.assert_called_with(url=cfg_url, password=None)
         mock_ws.wait_until_identified.assert_awaited()
@@ -172,6 +176,7 @@ class TestObsWsEmitter(unittest.IsolatedAsyncioTestCase):
         ctx.get_instance.assert_called_once_with(name=None)
 
         await obj.update('test text', args=None)
+        await asyncio.gather(obj._sending_task, return_exceptions=True)
 
         MockWebSocketClient.assert_called_with(url='ws://localhost:4455/', password=None)
         mock_ws.connect.assert_awaited()
@@ -213,6 +218,7 @@ class TestObsWsEmitter(unittest.IsolatedAsyncioTestCase):
         ctx.get_instance.assert_called_once_with(name=None)
 
         await obj.update(base.SlideBase(), args=None)
+        await asyncio.gather(obj._sending_task, return_exceptions=True)
 
         MockWebSocketClient.assert_called_with(url='ws://localhost:4455/', password=None)
         mock_ws.connect.assert_awaited()
@@ -256,6 +262,7 @@ class TestObsWsEmitter(unittest.IsolatedAsyncioTestCase):
         ctx.get_instance.assert_called_once_with(name=None)
 
         await obj.update(base.SlideBase(), args=None)
+        await asyncio.gather(obj._sending_task, return_exceptions=True)
 
         MockWebSocketClient.assert_called_with(url='ws://localhost:4455/', password=None)
         mock_ws.connect.assert_awaited()
@@ -308,6 +315,7 @@ class TestObsWsEmitter(unittest.IsolatedAsyncioTestCase):
         obj.logger.warning = MagicMock()
 
         await obj.update('test text', args=None)
+        await asyncio.gather(obj._sending_task, return_exceptions=True)
 
         MockWebSocketClient.assert_called_with(url=cfg_url, password=cfg_password)
         mock_ws.connect.assert_awaited()


### PR DESCRIPTION

### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Create a coroutine for sending text.

### Motivation

When the connection is not established soon, it could block entire process. If using with other output types, the text was not updated soon in the other types.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Tested with a configuration below.
Checked the typed text is displayed soon even though it takes time to make the connection in obsws.

```yaml
steps:
  - type: stdin
    name: in

  - type: obsws
    url: ws://192.168.0.1:4455/
    source_name: source

  - type: stdout
    src: in
```

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
