### PR TITLE
.github: Rename windows package in CI

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+
+    - title: New Features
+      labels:
+        - enhancement
+
+    - title: Bug Fixes
+      labels:
+        - bug
+
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -10,7 +10,7 @@ on:
       - 'test/**'
 
 env:
-  artifactName: ${{ contains(github.ref_name, '/') && 'artifact' || github.ref_name }}
+  tagName: ${{ contains(github.ref_name, '/') && 'artifact' || github.ref_name }}
 
 jobs:
   windows:
@@ -59,8 +59,14 @@ jobs:
           }
           Compress-Archive @compress
 
+      - name: rename
+        if: github.ref_type == 'tag'
+        shell: pwsh
+        run: |
+          Rename-Item -Path 'dist/slidetextbridge.zip' -NewName 'slidetextbridge-${{ env.tagName }}.zip'
+
       - name: upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.artifactName }}-windows
-          path: dist/slidetextbridge.zip
+          name: ${{ env.tagName }}-windows
+          path: dist/slidetextbridge*.zip

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -65,6 +65,9 @@ jobs:
         run: |
           Rename-Item -Path 'dist/slidetextbridge.zip' -NewName 'slidetextbridge-${{ env.tagName }}.zip'
 
+      - run: |
+          dist/slidetextbridge/slidetextbridge.exe -h
+
       - name: upload
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -70,3 +70,21 @@ jobs:
         with:
           name: ${{ env.tagName }}-windows
           path: dist/slidetextbridge*.zip
+
+  release:
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
+    needs: ['windows']
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.tagName }}-windows
+
+      - uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8
+        with:
+          draft: true
+          files: slidetextbridge*.zip
+          generate_release_notes: true


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

This PR adds a workflow to automatically generate a release on GitHub.

During build flow, the ZIP package for Windows will be renamed so that the ZIP package has the version in it's file name.

Then, the release will be generated with the ZIP package.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Tested with the tag [0.3.0-alpha3](https://github.com/norihiro/slidetextbridge/actions/runs/16497285158).

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
