### PR TITLE
config: Inherit types.SimpleNamespace for ConfigBase

### DIFF
--- a/src/slidetextbridge/core/config.py
+++ b/src/slidetextbridge/core/config.py
@@ -2,9 +2,10 @@
 Configuration data structure
 '''
 
+import types
 _LIB_KEYS = ('_location', )
 
-class ConfigBase():
+class ConfigBase(types.SimpleNamespace):
     '''
     Base class to hold configuration data
     '''

--- a/src/slidetextbridge/plugins/openlp.py
+++ b/src/slidetextbridge/plugins/openlp.py
@@ -28,30 +28,11 @@ def _filter_by_types(slide, item):
         return slide
     return None
 
-class OpenLPCaptureConfig(config.ConfigBase):
-    'Configuration for OpenLPCapture'
-    host: str
-    port: int
-    port_ws:int
-    def __init__(self):
-        super().__init__()
-        base.set_config_arguments(self, has_src=False)
-        self.add_argment('host', type=str, default='localhost')
-        self.add_argment('port', type=int, default=4316)
-        self.add_argment('port_ws', type=int, default=None)
-
-    def parse(self, d):
-        super().parse(d)
-        if not self.port_ws:
-            self.port_ws = self.port + 1
-
 
 class OpenLPCapture(base.PluginBase):
     '''
     Get text from OpenLP
     '''
-
-    cfg: OpenLPCaptureConfig
 
     @staticmethod
     def type_name():
@@ -60,8 +41,15 @@ class OpenLPCapture(base.PluginBase):
     @staticmethod
     def config(data):
         'Return the config object'
-        cfg = OpenLPCaptureConfig()
+        cfg = config.ConfigBase()
+        base.set_config_arguments(cfg, has_src=False)
+        cfg.add_argment('host', type=str, default='localhost')
+        cfg.add_argment('port', type=int, default=4316)
+        cfg.add_argment('port_ws', type=int, default=None)
+
         cfg.parse(data)
+        if not cfg.port_ws:
+            cfg.port_ws = cfg.port + 1
         return cfg
 
     def __init__(self, ctx, cfg=None):


### PR DESCRIPTION

### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Inherits types.SimpleNamespace to ConfigBase to avoid errors from Mypy when accessing the fields of the parameters.
Also removes `OpenLPCaptureConfig`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Unit-test passed.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
