### PR TITLE
.github: Add code-sign step for Windows binary file

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -49,6 +49,19 @@ jobs:
         run: |
           copy data/basic-config.yaml dist/slidetextbridge/config.yaml
 
+      - name: Code-sign
+        uses: sslcom/esigner-codesign@develop
+        # TODO: if: github.ref_type == 'tag'
+        with:
+          command: sign
+          username: ${{secrets.ES_USERNAME}}
+          password: ${{secrets.ES_PASSWORD}}
+          credential_id: ${{secrets.ES_CREDENTIAL_ID}}
+          totp_secret: ${{secrets.ES_TOTP_SECRET}}
+          file_path: ${{ github.workspace }}/dist/slidetextbridge/slidetextbridge.exe
+          override: true
+          signing_method: v1
+
       - name: archive
         shell: pwsh
         run: |


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

This PR adds a step to code-sign the EXE file.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Will test the artifact with `osslsigncode verify -in slidetextbridge.exe`.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
